### PR TITLE
conexión del panel de Administración con Crear reservas del front

### DIFF
--- a/src/components/pages/AdminReservas.jsx
+++ b/src/components/pages/AdminReservas.jsx
@@ -32,15 +32,9 @@ const AdminReservas = () => {
     setCargando(false);
   };
 
-  useEffect(() => {
-    // ✅ Si viene de ReservarCancha, usar esas reservas
-    if (location.state?.reservas) {
-      setReservas(location.state.reservas);
-      setCargando(false);
-    } else {
-      obtenerReservas();
-    }
-  }, [location.state]);
+useEffect(() => {
+  obtenerReservas();
+}, []);
 
   const reservasFiltradas = useMemo(() => {
     const texto = busqueda.trim().toLowerCase();


### PR DESCRIPTION
📝 Descripción
Rama: fix/reservas-sync-adminListado

🛠 Cambios realizados
	•	Se eliminó el uso de location.state para pasar reservas entre componentes.
	•	AdminReservas ahora siempre obtiene los datos directamente desde el endpoint GET /api/canchas.
	•	Se ajustó el flujo de navegación luego de crear una reserva para evitar inconsistencias en el listado.

🎯 Resultado
	•	Se corrigió el problema del renglón en blanco en el panel.
	•	Se garantiza que el listado siempre refleje exactamente lo que está persistido en el back.
	•	Se mejora la consistencia del flujo entre creación y visualización de reservas.
